### PR TITLE
Bumped to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,62 +2,76 @@
 
 ## Unreleased
 
-* Up to date
+- Up to date
+
+## [1.3.1] - 2020-12-03
+
+### Added
+
+- New Godot binaries compiled for the Raspberry Pi 4 (`godot-engine-2.1.6-rpi4`).
+
+### Fixed
+
+- An [audio issue](https://github.com/godotengine/godot/pull/43928) affecting the Raspberry Pi 4. All FRT and Godot "emulators" for the Raspberry Pi 4 have been updated with that fix.
+
+### Changed
+
+- Updated FRT binaries to [v0.9.9a](https://github.com/efornara/frt/releases/tag/0.9.9a).
 
 ## [1.3.0] - 2020-11-23
 
 ### Added
 
-* Support for the Raspberry Pi 4.
-* New Godot binaries compiled specifically for the Raspberry Pi 4 (`godot-engine-x.x.x-rpi4`).
-* A new option in the scriptmodule's configuration menu to force Godot to use the GLES2 video driver on single-board computers, such as the Raspberry Pi.
-* A [compatibility list](https://docs.google.com/spreadsheets/d/1ybU_NHqhnJmZnlP9YDDGEf4BJ5nInbfsVVQtQCM7rYw/edit?usp=sharing) to check which games work.
+- Support for the Raspberry Pi 4.
+- New Godot binaries compiled specifically for the Raspberry Pi 4 (`godot-engine-x.x.x-rpi4`).
+- A new option in the scriptmodule's configuration menu to force Godot to use the GLES2 video driver on single-board computers, such as the Raspberry Pi.
+- A [compatibility list](https://docs.google.com/spreadsheets/d/1ybU_NHqhnJmZnlP9YDDGEf4BJ5nInbfsVVQtQCM7rYw/edit?usp=sharing) to check which games work.
 
 ### Changed
 
-* Updated FRT binaries to [v0.9.8](https://github.com/efornara/frt/releases/tag/0.9.8).
-* Updated Godot versions (`3.2.3`).
+- Updated FRT binaries to [v0.9.8](https://github.com/efornara/frt/releases/tag/0.9.8).
+- Updated Godot versions (`3.2.3`).
 
 ## [1.2.3] - 2020-02-04
 
 ### Changed
 
-* Updated FRT binaries to [v0.9.7](https://github.com/efornara/frt/releases/tag/0.9.7).
-* Updated Godot versions (`2.1.6`, `3.0.6`, `3.1.2` and `3.2.0`).
+- Updated FRT binaries to [v0.9.7](https://github.com/efornara/frt/releases/tag/0.9.7).
+- Updated Godot versions (`2.1.6`, `3.0.6`, `3.1.2` and `3.2.0`).
 
 ## [1.2.2] - 2019-11-08
 
 ### Added
 
-* Remove `emulators.cfg` before creating a new one.
-* New documentation on how to properly install the script.
+- Remove `emulators.cfg` before creating a new one.
+- New documentation on how to properly install the script.
 
 ## [1.2.1] - 2019-11-08
 
 ### Changed
 
-* Removed bin files from the repository. The bin files are now in its own [release](https://github.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/releases).
-* Now the scriptmodule's download url is connected to the script's version.
+- Removed bin files from the repository. The bin files are now in its own [release](https://github.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/releases).
+- Now the scriptmodule's download url is connected to the script's version.
 
 ### Deprecated
 
-* Don't use versions prior to **v1.2.0**. The download url won't work.
+- Don't use versions prior to **v1.2.0**. The download url won't work.
 
 ## [1.2.0] - 2019-11-08
 
 ### Added
 
-* Support for GPIO/Virtual keyboards for single board computers, such as the Raspberry Pi.
-* Licenses for Godot and FRT.
+- Support for GPIO/Virtual keyboards for single board computers, such as the Raspberry Pi.
+- Licenses for Godot and FRT.
 
 ### Changed
 
-*  Now the scriptmodule only downloads the binaries needed for a particular platform instead of cloning the whole repository, thus downloading all the binaries.
+- Now the scriptmodule only downloads the binaries needed for a particular platform instead of cloning the whole repository, thus downloading all the binaries.
 
 ## [1.1.0] - 2019-10-25
 
-* Updated FRT binaries to [v0.9.6](https://github.com/efornara/frt/releases/tag/0.9.6).
+- Updated FRT binaries to [v0.9.6](https://github.com/efornara/frt/releases/tag/0.9.6).
 
 ## [1.0.0] - 2019-08-21
 
-* Released stable version.
+- Released stable version.

--- a/README.md
+++ b/README.md
@@ -322,3 +322,5 @@ Thanks to:
 - Source code: [MIT License](/LICENSE).
 - Godot logo: [CC BY](https://creativecommons.org/licenses/by/3.0/).
 - Pixel Godot logo: [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+- Godot - Game Engine: [MIT License](/LICENSE_GODOT).
+- FRT - A Godot platform targeting single board computers: [MIT License](/LICENSE_FRT).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A scriptmodule to install a Godot "emulator" for RetroPie.
 
 Thanks to [@efornara](https://github.com/efornara) (for creating [FRT - A Godot "platform" targeting single board computers](https://github.com/efornara/frt)) you can now **play\*** games made with [Godot](https://godotengine.org/) on the Raspberry Pi (and other single-board computers) using [RetroPie](https://retropie.org.uk/).
 
-**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or Godot 2.x.x) and they must not use any "fancy VFX", like particles, heavy shaders and other CPU/GPU demanding stuff and should preferably be 2D.**
+**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or Godot 2.x.x), they must not use any "fancy VFX", like particles, heavy shaders and other CPU/GPU demanding stuff and should preferably be 2D.**
 
 If you are running RetroPie on an `x86` Linux PC, the Godot "emulator" uses the **Linux/X11-32bits** export template instead of **FRT**, so most games should work fine.
 
@@ -17,7 +17,7 @@ You can find Godot games using the following links:
 - https://itch.io/games/made-with-godot
 - https://itch.io/games/tag-godot
 
-Most games are free to dowload, some are "pay what you want" with a suggested price and a few are paid. If you like the game, consider supporting the authors 😊.
+Most games are free to dowload, some are "pay what you want" with a suggested price (including free) and a few are paid. If you like the game, consider supporting the authors 😊.
 
 **NOTE**:
 
@@ -137,16 +137,20 @@ A new `godot-engine` folder will be created in `/home/pi/RetroPie/roms/`, where 
 
 For example, if you download a game from https://itch.io/, the downloaded `.zip` usually contains 2 files: the executable and the game. The later is, most of the times, a `.pck` file. That's the one we want. Just copy it to `/home/pi/RetroPie/roms/godot-engine`.
 
-The script installs different versions of the "emulator" for maximum compatibility:
+The script installs different versions of the Godot "emulator" for maximum compatibility:
 
 - `2.1.6`
 - `3.0.6`
 - `3.1.2`
 - `3.2.3`
 
-If you are using an `x86` PC, the "emulators" used are Godot's export templates downloaded from https://godotengine.org/download/.
+### x86 Linux PC "emulator"
+
+If you are using an `x86` Linux PC, the "emulators" used are Godot's export templates downloaded from https://godotengine.org/download/.
 
 - `godot-engine-x.x.x-x86`
+
+### Raspberry Pi "emulator"
 
 For the Raspberry Pi, the script will auto-detect if you are using a `0/1`, a `2/3` or a `4` version and it will install the proper **FRT** "emulators".
 
@@ -157,6 +161,8 @@ For the Raspberry Pi, the script will auto-detect if you are using a `0/1`, a `2
 In the case of the **Raspberry Pi 4**, the script will install additional Godot "emulators" specifically compiled for it.
 
 - `godot-engine-x.x.x-rpi4`
+
+### Other single-board computers "emulator"
 
 For any `arm64` single-board computer, the script will install the proper **FRT** "emulators".
 
@@ -196,7 +202,7 @@ and then go to:
 
 **Warning! When using a GPIO/Virtual keyboard, the actual keyboard won't work anymore. But you can always remove the GPIO/Virtual keyboard (see below).**
 
-As of **v1.2.0**, when using the **FRT** emulator, you can use a GPIO/Virtual keyboard, such as [GPIOnext](https://github.com/mholgatem/GPIOnext) or [Adafruit's Retrogame](https://github.com/adafruit/Adafruit-Retrogame).
+As of **v1.2.0**, when using the **FRT** "emulator", you can use a GPIO/Virtual keyboard, such as [GPIOnext](https://github.com/mholgatem/GPIOnext) or [Adafruit's Retrogame](https://github.com/adafruit/Adafruit-Retrogame).
 
 ### Add/Remove a GPIO/Virtual keyboard
 
@@ -232,7 +238,7 @@ If the game you are trying to play doesn't work, it will most likely be because 
 
 Try changing the Godot "emulator" version in the [runcommand](https://github.com/RetroPie/RetroPie-Setup/wiki/runcommand).
 
-If you downloaded the game from https://itch.io, there a good chance the author has stated which version of Godot that game uses.
+If you downloaded the game from https://itch.io, there's a good chance the author stated which version of Godot that game uses.
 
 In case none of the "emulators" work... **Sorry 😔**.
 
@@ -310,17 +316,18 @@ Me 😛 [@hiulit](https://github.com/hiulit).
 
 Thanks to:
 
-- Emanuele Fornara [@efornara](https://github.com/efornara) - For creating [FRT - A Godot "platform" targeting single board computers](https://github.com/efornara/frt).
+- Juan Linietsky ([@reduz](https://github.com/reduz)), Ariel Manzur ([@punto-](https://github.com/punto-)), Rémi Verschelde ([@akien-mga](https://github.com/akien-mga)) and all the Godot contributors - For creating and maintaining the [Godot Engine](https://github.com/godotengine/godot).
+- Emanuele Fornara ([@efornara](https://github.com/efornara)) - For creating [FRT - A Godot "platform" targeting single board computers](https://github.com/efornara/frt).
 - Andrea Calabró - For creating the **Godot logo**. Changes made to it:
   - Created an outline version.
-- Alícia Folgarona Ribot (Alfórium Studios) [@alforiumstudios](https://twitter.com/alforiumstudios) - For creating the **Pixel Godot logo**. Changes made to it:
+- Alícia Folgarona Ribot (Alfórium Studios - [@alforiumstudios](https://twitter.com/alforiumstudios)) - For creating the **Pixel Godot logo**. Changes made to it:
   - New colors.
   - Added white outline.
 
 ## LICENSE
 
 - Source code: [MIT License](/LICENSE).
-- Godot logo: [CC BY](https://creativecommons.org/licenses/by/3.0/).
-- Pixel Godot logo: [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 - Godot - Game Engine: [MIT License](/LICENSE_GODOT).
 - FRT - A Godot platform targeting single board computers: [MIT License](/LICENSE_FRT).
+- Godot logo: [CC BY](https://creativecommons.org/licenses/by/3.0/).
+- Pixel Godot logo: [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/).

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ A scriptmodule to install a Godot "emulator" for RetroPie.
 
 Thanks to [@efornara](https://github.com/efornara) (for creating [FRT - A Godot "platform" targeting single board computers](https://github.com/efornara/frt)) you can now **play\*** games made with [Godot](https://godotengine.org/) on the Raspberry Pi (and other single-board computers) using [RetroPie](https://retropie.org.uk/).
 
-**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or maybe Godot 2.x.x) and that they must not use any "fancy VFX", like particles and other CPU/GPU demanding stuff.**
+**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or Godot 2.x.x) and they must not use any "fancy VFX", like particles, heavy shaders and other CPU/GPU demanding stuff.**
 
-If you are running RetroPie on an `x86` PC, the Godot "emulator" uses the **Linux/X11-32bits** export template instead of **FRT**, so most games should work fine.
+If you are running RetroPie on an `x86` Linux PC, the Godot "emulator" uses the **Linux/X11-32bits** export template instead of **FRT**, so most games should work fine.
+
+## Where to find games
 
 There are plenty of games made with Godot, most of them hosted on https://itch.io/.
 
@@ -17,7 +19,14 @@ You can find Godot games using the following links:
 
 **NOTE**:
 
-When you download a game from https://itch.io/, you have to look for a `.pck` file. Those files will most likely be found on Linux downloads (maybe on Windows too).
+When you download a game from https://itch.io/, you have to look for a `.pck` file. Those files will most likely be found on **Linux** downloads (maybe on the **Windows** downloads too).
+
+If you can't find a `.pck` file on neither the Linux nor the Windows downloads, you can try the **Mac/OSX** downloads. You'll have to:
+
+* Unzip the `.zip` file.
+* Go to `Contents -> Resources` and in this folder there sould be the `.pck` file.
+
+## Compatibility list
 
 Take a look at the [compatibility list](https://docs.google.com/spreadsheets/d/1ybU_NHqhnJmZnlP9YDDGEf4BJ5nInbfsVVQtQCM7rYw/edit?usp=sharing) to check which games work. Everyone can contribute to the list.
 
@@ -62,7 +71,7 @@ The script assumes that you are running it on a Raspberry Pi with the `RetroPie-
 * `--install`: Install the scriptmodule.
 * `--uninstall`: Uninstall the scriptmodule.
 * `--update`: Update the scriptmodule.
-* `--version`: Show script version.
+* `--version`: Show the script's version.
 
 ## Examples
 
@@ -100,7 +109,7 @@ Update the scriptmodule.
 
 ### `--version`
 
-Show script version.
+Show the script's version.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Thanks to [@efornara](https://github.com/efornara) (for creating [FRT - A Godot 
 
 If you are running RetroPie on an `x86` Linux PC, the Godot "emulator" uses the **Linux/X11-32bits** export template instead of **FRT**, so most games should work fine.
 
-## Where to find games
+## Where to find games made with Godot
 
 There are plenty of games made with Godot, most of them hosted on https://itch.io/.
 
@@ -17,9 +17,11 @@ You can find Godot games using the following links:
 * https://itch.io/games/made-with-godot
 * https://itch.io/games/tag-godot
 
+Most games are free to dowload and some are "pay what you want" with a suggested price. If you like the game, consider supporting the authors 😊.
+
 **NOTE**:
 
-When you download a game from https://itch.io/, you have to look for a `.pck` file. Those files will most likely be found on **Linux** downloads (maybe on the **Windows** downloads too).
+When you download a game from https://itch.io/, you have to look for a `.pck` file to be able to play the game using the Godot "emulator". Those files will most likely be found on **Linux** downloads (maybe on **Windows** downloads too).
 
 If you can't find a `.pck` file on neither the Linux nor the Windows downloads, you can try the **Mac/OSX** downloads. You'll have to:
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The script installs different versions of the Godot "emulator" for maximum compa
 - `3.1.2`
 - `3.2.3`
 
-### x86 Linux PC "emulator"
+### Linux PC (x86) "emulator"
 
 If you are using an `x86` Linux PC, the "emulators" used are Godot's export templates downloaded from https://godotengine.org/download/.
 
@@ -162,7 +162,7 @@ In the case of the **Raspberry Pi 4**, the script will install additional Godot 
 
 - `godot-engine-x.x.x-rpi4`
 
-### Other single-board computers "emulator"
+### Other single-board computers (arm64) "emulator"
 
 For any `arm64` single-board computer, the script will install the proper **FRT** "emulators".
 

--- a/README.md
+++ b/README.md
@@ -4,29 +4,30 @@ A scriptmodule to install a Godot "emulator" for RetroPie.
 
 Thanks to [@efornara](https://github.com/efornara) (for creating [FRT - A Godot "platform" targeting single board computers](https://github.com/efornara/frt)) you can now **play\*** games made with [Godot](https://godotengine.org/) on the Raspberry Pi (and other single-board computers) using [RetroPie](https://retropie.org.uk/).
 
-**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or Godot 2.x.x) and they must not use any "fancy VFX", like particles, heavy shaders and other CPU/GPU demanding stuff.**
+**\*Games that (would) work on a Raspberry Pi must have been created with Godot version >= 3.1.x using GLES2 (or Godot 2.x.x) and they must not use any "fancy VFX", like particles, heavy shaders and other CPU/GPU demanding stuff and should preferably be 2D.**
 
 If you are running RetroPie on an `x86` Linux PC, the Godot "emulator" uses the **Linux/X11-32bits** export template instead of **FRT**, so most games should work fine.
 
 ## Where to find games made with Godot
 
-There are plenty of games made with Godot, most of them hosted on https://itch.io/.
+There are plenty of games made with Godot, most of them hosted on https://itch.io.
 
 You can find Godot games using the following links:
 
-* https://itch.io/games/made-with-godot
-* https://itch.io/games/tag-godot
+- https://itch.io/games/made-with-godot
+- https://itch.io/games/tag-godot
 
-Most games are free to dowload and some are "pay what you want" with a suggested price. If you like the game, consider supporting the authors 😊.
+Most games are free to dowload, some are "pay what you want" with a suggested price and a few are paid. If you like the game, consider supporting the authors 😊.
 
 **NOTE**:
 
-When you download a game from https://itch.io/, you have to look for a `.pck` file to be able to play the game using the Godot "emulator". Those files will most likely be found on **Linux** downloads (maybe on **Windows** downloads too).
+When you download a game from https://itch.io, you have to look for a `.pck` file to be able to play the game using the Godot "emulator". Those files will most likely be found on **Linux downloads** (maybe on **Windows downloads**
+ too).
 
-If you can't find a `.pck` file on neither the Linux nor the Windows downloads, you can try the **Mac/OSX** downloads. You'll have to:
+If you can't find a `.pck` file on neither the Linux nor the Windows downloads, you can try the **Mac/OSX downloads**. You'll have to:
 
-* Unzip the `.zip` file.
-* Go to `Contents -> Resources` and in this folder there sould be the `.pck` file.
+- Unzip the `.zip` file.
+- Go to `Contents -> Resources` and in this folder there sould be the `.pck` file.
 
 ## Compatibility list
 
@@ -69,11 +70,11 @@ The script assumes that you are running it on a Raspberry Pi with the `RetroPie-
 ```
 ## Options
 
-* `--help`: Print the help message and exit.
-* `--install`: Install the scriptmodule.
-* `--uninstall`: Uninstall the scriptmodule.
-* `--update`: Update the scriptmodule.
-* `--version`: Show the script's version.
+- `--help`: Print the help message and exit.
+- `--install`: Install the scriptmodule.
+- `--uninstall`: Uninstall the scriptmodule.
+- `--update`: Update the scriptmodule.
+- `--version`: Show the script's version.
 
 ## Examples
 
@@ -127,10 +128,10 @@ sudo /home/pi/RetroPie-Setup/retropie_setup.sh
 
 and then go to:
 
-* Manage packages
-* Manage optional packages
-* godot-engine
-* Install from source
+- Manage packages
+- Manage optional packages
+- godot-engine
+- Install from source
 
 A new `godot-engine` folder will be created in `/home/pi/RetroPie/roms/`, where you can put your games using the `.pck` and `.zip` extensions.
 
@@ -143,27 +144,97 @@ The script installs different versions of the "emulator" for maximum compatibili
 - `3.1.2`
 - `3.2.3`
 
-If the game you are trying to play doesn't work, try changing the "emulator" in the [runcommand](https://github.com/RetroPie/RetroPie-Setup/wiki/runcommand).
-
 If you are using an `x86` PC, the "emulators" used are Godot's export templates downloaded from https://godotengine.org/download/.
 
-* `godot-engine-x.x.x-x86`
+- `godot-engine-x.x.x-x86`
 
 For the Raspberry Pi, the script will auto-detect if you are using a `0/1`, a `2/3` or a `4` version and it will install the proper **FRT** "emulators".
 
-* `godot-engine-x.x.x-frt-rpi0-1`
-* `godot-engine-x.x.x-frt-rpi2-3`
-* `godot-engine-x.x.x-frt-rpi4`
+- `godot-engine-x.x.x-frt-rpi0-1`
+- `godot-engine-x.x.x-frt-rpi2-3`
+- `godot-engine-x.x.x-frt-rpi4`
 
-In the case of the **Raspberry Pi 4**, the script will install additional Godot "emulators", starting at `v3.1.2`, specifically compiled for it.
+In the case of the **Raspberry Pi 4**, the script will install additional Godot "emulators" specifically compiled for it.
 
-* `godot-engine-x.x.x-rpi4`
+- `godot-engine-x.x.x-rpi4`
 
 For any `arm64` single-board computer, the script will install the proper **FRT** "emulators".
 
-* `godot-engine-x.x.x-frt-arm64`
+- `godot-engine-x.x.x-frt-arm64`
 
-In case none of the "emulators" work... **Sorry :(**
+## Uninstall the Godot "emulator" from RetroPie-Setup
+
+Run:
+
+```
+sudo /home/pi/RetroPie-Setup/retropie_setup.sh
+```
+
+and then go to:
+
+- Manage packages
+- Manage optional packages
+- godot-engine
+- Remove
+
+## Update the Godot "emulator" from RetroPie-Setup
+
+Run:
+
+```
+sudo /home/pi/RetroPie-Setup/retropie_setup.sh
+```
+
+and then go to:
+
+- Manage packages
+- Manage optional packages
+- godot-engine
+- Update from source
+
+## Using a GPIO/Virtual keyboard
+
+**Warning! When using a GPIO/Virtual keyboard, the actual keyboard won't work anymore. But you can always remove the GPIO/Virtual keyboard (see below).**
+
+As of **v1.2.0**, when using the **FRT** emulator, you can use a GPIO/Virtual keyboard, such as [GPIOnext](https://github.com/mholgatem/GPIOnext) or [Adafruit's Retrogame](https://github.com/adafruit/Adafruit-Retrogame).
+
+### Add/Remove a GPIO/Virtual keyboard
+
+Run:
+
+```
+sudo /home/pi/RetroPie-Setup/retropie_setup.sh
+```
+
+and then go to:
+
+- Configuration/tools
+- godot-engine
+
+Select **Use a GPIO/Virtual keyboard**.
+
+![Configuration dialog](example-images/configuration-dialog.png)
+
+Select **Yes**.
+
+![GPIO/Virtual keyboard dialog](example-images/gpio-virtual-keyboard-dialog.png)
+
+You will be prompted with a menu showing all the results from the command `cat /proc/bus/input/devices`. Select the GPIO/Virtual keyboard that you want.
+
+If you want to to reverse that action, follow the same steps and select **No**.
+
+ 
+## Troubleshooting
+
+### A game doesn't launch or crashes
+
+If the game you are trying to play doesn't work, it will most likely be because it was made with another version of Godot.
+
+Try changing the Godot "emulator" version in the [runcommand](https://github.com/RetroPie/RetroPie-Setup/wiki/runcommand).
+
+If you downloaded the game from https://itch.io, there a good chance the author has stated which version of Godot that game uses.
+
+In case none of the "emulators" work... **Sorry 😔**.
 
 Well... there's **one last thing** you could try. See the section below.
 
@@ -183,8 +254,8 @@ sudo /home/pi/RetroPie-Setup/retropie_setup.sh
 
 and then go to:
 
-* Configuration/tools
-* godot-engine
+- Configuration/tools
+- godot-engine
 
 Select **Force GLES2 video driver**.
 
@@ -196,95 +267,16 @@ Select **Yes**.
 
 If you want to to reverse that action, follow the same steps and select **No**.
 
-## Uninstall the Godot "emulator" from RetroPie-Setup
 
-Run:
-
-```
-sudo /home/pi/RetroPie-Setup/retropie_setup.sh
-```
-
-and then go to:
-
-* Manage packages
-* Manage optional packages
-* godot-engine
-* Remove
-
-## Update the Godot "emulator" from RetroPie-Setup
-
-Run:
-
-```
-sudo /home/pi/RetroPie-Setup/retropie_setup.sh
-```
-
-and then go to:
-
-* Manage packages
-* Manage optional packages
-* godot-engine
-* Update from source
-
-## Using a GPIO/Virtual keyboard
-
-**Warning! When using a GPIO/Virtual keyboard, the actual keyboard won't work anymore. But you can always remove the GPIO/Virtual keyboard (see below).**
-
-As of **v1.2.0**, when using the **FRT** emulator, you can use a GPIO/Virtual keyboard, such as [GPIOnext](https://github.com/mholgatem/GPIOnext) or [Adafruit's Retrogame](https://github.com/adafruit/Adafruit-Retrogame).
-
-### Add a GPIO/Virtual keyboard
-
-Run:
-
-```
-sudo /home/pi/RetroPie-Setup/retropie_setup.sh
-```
-
-and then go to:
-
-* Configuration/tools
-* godot-engine
-
-Select **Use a GPIO/Virtual keyboard**.
-
-![Configuration dialog](example-images/configuration-dialog.png)
-
-Select **Yes**.
-
-![GPIO/Virtual keyboard dialog](example-images/gpio-virtual-keyboard-dialog.png)
-
-You will be prompted with a menu showing all the results from the command `cat /proc/bus/input/devices`. Select the GPIO/Virtual keyboard that you want.
-
-### Remove the GPIO/Virtual keyboard
-
-If you don't want to use the GPIO/Virtual keyboard anymore, run:
-
-```
-sudo /home/pi/RetroPie-Setup/retropie_setup.sh
-```
-
-and then go to:
-
-* Configuration/tools
-* godot-engine
-
-Select **Use a GPIO/Virtual keyboard**.
-
-![Configuration dialog](example-images/configuration-dialog.png)
-
-Select **No**.
-
-![GPIO/Virtual keyboard dialog](example-images/gpio-virtual-keyboard-dialog.png)
- 
 ## How to create a new Godot system for an EmulationStation theme
 
 As there is no way to create a script to automate this, because themes don't have the same structure, the best way is to manually create a new system in your preferred theme.
 
-* [Download](https://raw.githubusercontent.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/master/art/system.svg) the Godot `system.svg`.
-* [Download](https://raw.githubusercontent.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/master/art/controller.svg) the Godot `controller.svg`.
-* Copy any system folder in your theme (e.g. `/etc/emulationstation/themes/[THEME]/nes`).
-* Rename it as `godot-engine`.
-* Move the Godot `system.svg` and `controller.svg` to the `godot-engine/art` folder.
+- [Download](https://raw.githubusercontent.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/master/art/system.svg) the Godot `system.svg`.
+- [Download](https://raw.githubusercontent.com/hiulit/RetroPie-Godot-Game-Engine-Emulator/master/art/controller.svg) the Godot `controller.svg`.
+- Copy any system folder in your theme (e.g. `/etc/emulationstation/themes/[THEME]/nes`).
+- Rename it as `godot-engine`.
+- Move the Godot `system.svg` and `controller.svg` to the `godot-engine/art` folder.
 
 **NOTE**:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RetroPie Godot Game Engine "Emulator"
+# RetroPie Godot Game Engine "Emulator" ![GitHub release (latest by date)](https://img.shields.io/github/v/release/hiulit/RetroPie-Godot-Game-Engine-Emulator)
 
 A scriptmodule to install a Godot "emulator" for RetroPie.
 

--- a/scriptmodules/emulators/godot-engine.sh
+++ b/scriptmodules/emulators/godot-engine.sh
@@ -25,7 +25,7 @@ rp_module_flags="x86 aarch64 rpi1 rpi2 rpi3 rpi4"
 
 # Global variables ##################################
 
-SCRIPT_VERSION="1.3.0"
+SCRIPT_VERSION="1.3.1"
 GODOT_VERSIONS=(
     "2.1.6"
     "3.0.6"
@@ -33,6 +33,7 @@ GODOT_VERSIONS=(
     "3.2.3"
 )
 GODOT_ONLY_RPI_4_VERSIONS=(
+    "2.1.6"
     "3.1.2"
     "3.2.3" 
 )

--- a/setup-godot-engine-scriptmodule.sh
+++ b/setup-godot-engine-scriptmodule.sh
@@ -21,7 +21,7 @@ home="$(eval echo ~$user)"
 readonly RP_DIR="$home/RetroPie"
 readonly RP_ROMS_DIR="$RP_DIR/roms"
 
-readonly SCRIPT_VERSION="1.3.0"
+readonly SCRIPT_VERSION="1.3.1"
 readonly SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_FULL="$SCRIPT_DIR/$SCRIPT_NAME"

--- a/setup-godot-engine-scriptmodule.sh
+++ b/setup-godot-engine-scriptmodule.sh
@@ -192,13 +192,13 @@ function get_options() {
                 check_path "$2"
                 update
                 ;;
-#H -v,  --version                Show script version.
+#H -v,  --version                Show the script's version.
             -v|--version)
                 echo "$SCRIPT_VERSION"
                 ;;
             *)
                 echo >&2
-                echo "ERROR: invalid option '$1'" >&2
+                echo "ERROR: Invalid option '$1'." >&2
                 exit 2
                 ;;
         esac


### PR DESCRIPTION
### Added

- New Godot binaries compiled for the Raspberry Pi 4 (`godot-engine-2.1.6-rpi4`).

### Fixed

- An [audio issue](https://github.com/godotengine/godot/pull/43928) affecting the Raspberry Pi 4. All FRT and Godot "emulators" for the Raspberry Pi 4 have been updated with that fix.

### Changed

- Updated FRT binaries to [v0.9.9a](https://github.com/efornara/frt/releases/tag/0.9.9a).